### PR TITLE
Fix multiple problems when using this module in Deno

### DIFF
--- a/areIntervalsOverlapping/index.ts
+++ b/areIntervalsOverlapping/index.ts
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name areIntervalsOverlapping

--- a/clamp/index.ts
+++ b/clamp/index.ts
@@ -1,6 +1,7 @@
-import max from '../max.js'
-import min from '../min.js'
+import max from '../max/index.ts'
+import min from '../min/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name clamp

--- a/eachDayOfInterval/index.ts
+++ b/eachDayOfInterval/index.ts
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name eachDayOfInterval

--- a/eachMonthOfInterval/index.ts
+++ b/eachMonthOfInterval/index.ts
@@ -1,5 +1,6 @@
 import toDate from '../toDate/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name eachMonthOfInterval

--- a/eachQuarterOfInterval/index.ts
+++ b/eachQuarterOfInterval/index.ts
@@ -2,6 +2,7 @@ import addQuarters from '../addQuarters/index.ts'
 import startOfQuarter from '../startOfQuarter/index.ts'
 import toDate from '../toDate/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name eachQuarterOfInterval

--- a/eachWeekOfInterval/index.ts
+++ b/eachWeekOfInterval/index.ts
@@ -3,6 +3,7 @@ import addWeeks from '../addWeeks/index.ts'
 import startOfWeek from '../startOfWeek/index.ts'
 import toDate from '../toDate/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name eachWeekOfInterval

--- a/eachWeekendOfInterval/index.ts
+++ b/eachWeekendOfInterval/index.ts
@@ -2,6 +2,7 @@ import eachDayOfInterval from '../eachDayOfInterval/index.ts'
 import isSunday from '../isSunday/index.ts'
 import isWeekend from '../isWeekend/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
+import { Interval } from '../types.ts'
 
 /**
  * @name eachWeekendOfInterval

--- a/intervalToDuration/index.ts
+++ b/intervalToDuration/index.ts
@@ -9,6 +9,7 @@ import isValid from '../isValid/index.js'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
 import toDate from '../toDate/index.ts'
 import sub from '../sub/index.js'
+import { Duration, Interval } from '../types.ts'
 
 /**
  * @name intervalToDuration

--- a/locale/_lib/buildLocalizeFn/index.ts
+++ b/locale/_lib/buildLocalizeFn/index.ts
@@ -1,4 +1,4 @@
-import { Era, Quarter, Month, Day } from '../../../types.ts.ts'
+import { Era, Quarter, Month, Day } from '../../../types.ts'
 import {
   LocaleDayPeriod,
   LocalePatternWidth,

--- a/locale/de/_lib/match/index.ts
+++ b/locale/de/_lib/match/index.ts
@@ -1,7 +1,7 @@
 import buildMatchPatternFn from '../../../_lib/buildMatchPatternFn/index.ts'
 import buildMatchFn from '../../../_lib/buildMatchFn/index.ts'
 import type { Match } from '../../../types.ts'
-import type { Quarter } from '../../../../types.ts.ts'
+import type { Quarter } from '../../../../types.ts'
 
 const matchOrdinalNumberPattern = /^(\d+)(\.)?/i
 const parseOrdinalNumberPattern = /\d+/i

--- a/locale/types.ts
+++ b/locale/types.ts
@@ -3,7 +3,7 @@ import type {
   BuildLocalizeFnArgCallback,
   LocalizeUnitValues,
   LocalizeUnitValuesIndex,
-} from './_lib/buildLocalizeFn.js'
+} from './_lib/buildLocalizeFn/index.ts'
 
 export interface Locale {
   code: string

--- a/min/index.ts
+++ b/min/index.ts
@@ -43,7 +43,7 @@ import requiredArgs from '../_lib/requiredArgs/index.ts'
 export default function min(dirtyDatesArray: Array<Date | number>): Date {
   requiredArgs(1, arguments)
 
-  let datesArray: Date[] | number[]
+  let datesArray: Array<Date | number>;
   // `dirtyDatesArray` is Array, Set or Map, or object with custom `forEach` method
   if (dirtyDatesArray && typeof dirtyDatesArray.forEach === 'function') {
     datesArray = dirtyDatesArray

--- a/nextDay/index.ts
+++ b/nextDay/index.ts
@@ -1,5 +1,5 @@
-import addDays from '../addDays.js'
-import getDay from '../getDay.js'
+import addDays from '../addDays/index.ts'
+import getDay from '../getDay/index.ts'
 import { Day } from '../types.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
 

--- a/setDay/index.ts
+++ b/setDay/index.ts
@@ -2,7 +2,7 @@ import addDays from '../addDays/index.ts'
 import toDate from '../toDate/index.ts'
 import toInteger from '../_lib/toInteger/index.ts'
 import requiredArgs from '../_lib/requiredArgs/index.ts'
-import { LocalOptions, WeekStartOptions } from '../types.ts';
+import { LocaleOptions, WeekStartOptions } from '../types.ts';
 
 /**
  * @name setDay
@@ -38,7 +38,7 @@ import { LocalOptions, WeekStartOptions } from '../types.ts';
 export default function setDay(
     dirtyDate: Date | number,
     dirtyDay: number,
-    dirtyOptions?: WeekStartOptions & LocalOptions
+    dirtyOptions?: WeekStartOptions & LocaleOptions
 ): Date {
   requiredArgs(2, arguments)
 


### PR DESCRIPTION
* Import missing `Interval` and `Duration` from `types.ts`.
* Fix incorrect paths to submodules.
* Fix duplicate file ending in import statement.
* Fix typing of local variable in `min` function.
* Fix typo in `LocaleOptions` in import statement in `setDate/index.ts`.